### PR TITLE
Use correct runner label

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -17,7 +17,7 @@ jobs:
       # pinning to use rockcraft 1.3.0 feature `entrypoint-service`
       rockcraft-revisions: '{"amd64": "1783", "arm64": "1784"}'
       arch-skipping-maximize-build-space: '["arm64"]'
-      platform-labels: '{"amd64": ["self-hosted", "Linux", "AMD64", "jammy", "xlarge"], "arm64": ["self-hosted", "Linux", "ARM64", "jammy", "xlarge"]}'
+      platform-labels: '{"amd64": ["self-hosted", "Linux", "X64", "jammy", "xlarge"], "arm64": ["self-hosted", "Linux", "ARM64", "jammy", "xlarge"]}'
   run-tests:
     uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
     needs: [build-and-push-arch-specifics]


### PR DESCRIPTION
Apparently, our self-hosted runners use `x64` instead of `amd64`