### PR TITLE
skip maximize build space for amd64

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -16,7 +16,7 @@ jobs:
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       # pinning to use rockcraft 1.3.0 feature `entrypoint-service`
       rockcraft-revisions: '{"amd64": "1783", "arm64": "1784"}'
-      arch-skipping-maximize-build-space: '["arm64"]'
+      arch-skipping-maximize-build-space: '["arm64", "amd64"]'
       platform-labels: '{"amd64": ["self-hosted", "Linux", "X64", "jammy", "xlarge"], "arm64": ["self-hosted", "Linux", "ARM64", "jammy", "xlarge"]}'
   run-tests:
     uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main


### PR DESCRIPTION
Maximize build space seems to cause issues on xlarge self-hosted runners
https://github.com/canonical/envoy-rock/actions/runs/10176388060/job/28146432109