### PR TITLE
Adds base-files to the envoy rock

### DIFF
--- a/1.28.2/rockcraft.yaml
+++ b/1.28.2/rockcraft.yaml
@@ -22,6 +22,11 @@ services:
 entrypoint-service: envoy
 
 parts:
+  add-base-files:
+    plugin: nil
+    stage-packages:
+      - base-files
+
   envoy:
     plugin: nil
     source: https://github.com/envoyproxy/envoy.git


### PR DESCRIPTION
Pebble has an issue with starting the envoy service, as the rock is ``bare``-based, failing with the following error:

```
[pebble] Change 1 task (Start service "envoy") failed: cannot start
service: fork/exec /bin/envoy: no such file or directory
```

Adding the ``base-files`` ``stage-packages`` solves this issue.