### PR TITLE
Updates rockcraft.yaml file for arm64

### DIFF
--- a/1.28.2/rockcraft.yaml
+++ b/1.28.2/rockcraft.yaml
@@ -56,18 +56,18 @@ parts:
       # setup required libs
       arch="$(uname -m)"
       if [ "${arch}" == "x86_64" ]; then
-          url="https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz"
+          clang_llvm="clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04"
       elif [ "${arch}" == "aarch64" ]; then
-          url="https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz"
+          clang_llvm="clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz"
       else
         echo "Invalid platform for building envoy ('${arch}'). Exiting."
         exit 1
       fi
 
-      wget -q "${url}"
-      tar -xf clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04.tar.xz
-      bazel/setup_clang.sh clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04
-      export LLVM_ROOT=$PWD/clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04
+      wget -q "https://github.com/llvm/llvm-project/releases/download/llvmorg-18.1.8/${clang_llvm}.tar.xz"
+      tar -xf "./${clang_llvm}.tar.xz"
+      bazel/setup_clang.sh "${clang_llvm}"
+      export LLVM_ROOT="$PWD/${clang_llvm}"
       export PATH=${LLVM_ROOT}/bin:${PATH}
 
       # https://github.com/bazelbuild/rules_python/issues/1169
@@ -83,5 +83,5 @@ parts:
 
       # copy required files
       mkdir -p ${CRAFT_PART_INSTALL}/bin/ ${CRAFT_PART_INSTALL}/etc/envoy/
-      cp linux/amd64/build_envoy_sizeopt_stripped/envoy ${CRAFT_PART_INSTALL}/bin/envoy
+      cp "linux/${CRAFT_ARCH_BUILD_FOR}/build_envoy_sizeopt_stripped/envoy" ${CRAFT_PART_INSTALL}/bin/envoy
       cp configs/envoyproxy_io_proxy.yaml ${CRAFT_PART_INSTALL}/etc/envoy/envoy.yaml


### PR DESCRIPTION
Currently, the arm64 build fails because there is still amd64-related bits in the build script.