### PR TITLE
Updates the rock building process

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -13,7 +13,7 @@ jobs:
       owner: ${{ github.repository_owner }}
       trivy-image-config: "trivy.yaml"
       multiarch-awareness: true
-      cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
+      cache-action: "skip"
       # pinning to use rockcraft 1.3.0 feature `entrypoint-service`
       rockcraft-revisions: '{"amd64": "1783", "arm64": "1784"}'
       arch-skipping-maximize-build-space: '["arm64", "amd64"]'

--- a/1.28.2/rockcraft.yaml
+++ b/1.28.2/rockcraft.yaml
@@ -9,7 +9,6 @@ description: |
   Envoy is an open source edge and service proxy, designed for cloud-native applications.
 platforms:
   amd64:
-  arm64:
 
 services:
   envoy:


### PR DESCRIPTION
Building the envoy binary takes a significant amount of local storage. The rock building job fails at the moment while trying to save the container cache because it runs out of disk space. We should skip the caching steps.

The ``arm64`` binary currently fails. Remove it from the ``rockcraft.yaml`` definition until further notice.