### PR TITLE
Optimize rockcraft build

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -36,6 +36,7 @@ jobs:
     name: Combine Rocks and Push Multiarch Manifest
     uses: canonical/k8s-workflows/.github/workflows/assemble_multiarch_image.yaml@main
     needs: [build-and-push-arch-specifics]
+    if: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas != '[]' }}
     with:
-      rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.rock-metas }}
+      rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.changed-rock-metas }}
       dry-run: ${{ github.event_name != 'push' }}

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -16,8 +16,8 @@ jobs:
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       # pinning to use rockcraft 1.3.0 feature `entrypoint-service`
       rockcraft-revisions: '{"amd64": "2218", "arm64": "2222"}'
-      arch-skipping-maximize-build-space: '["arm64", "amd64"]'
-      platform-labels: '{"amd64": ["self-hosted", "Linux", "X64", "jammy", "xlarge"], "arm64": ["self-hosted", "Linux", "ARM64", "jammy", "large"]}'
+      arch-skipping-maximize-build-space: '["arm64"]'
+      platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
   run-tests:
     uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
     needs: [build-and-push-arch-specifics]

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -15,7 +15,7 @@ jobs:
       multiarch-awareness: true
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       # pinning to use rockcraft 1.3.0 feature `entrypoint-service`
-      rockcraft-revisions: '{"amd64": "1783", "arm64": "1784"}'
+      rockcraft-revisions: '{"amd64": "2218", "arm64": "2222"}'
       arch-skipping-maximize-build-space: '["arm64", "amd64"]'
       platform-labels: '{"amd64": ["self-hosted", "Linux", "X64", "jammy", "xlarge"], "arm64": ["self-hosted", "Linux", "ARM64", "jammy", "large"]}'
   run-tests:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -16,8 +16,8 @@ jobs:
       cache-action: ${{ (github.event_name == 'push') && 'save' || 'restore' }}
       # pinning to use rockcraft 1.3.0 feature `entrypoint-service`
       rockcraft-revisions: '{"amd64": "2218", "arm64": "2222"}'
-      arch-skipping-maximize-build-space: '["arm64"]'
-      platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
+      arch-skipping-maximize-build-space: '["arm64", "amd64"]'
+      platform-labels: '{"amd64": ["self-hosted", "Linux", "X64", "jammy", "xlarge"], "arm64": ["self-hosted", "Linux", "ARM64", "jammy", "large"]}'
   run-tests:
     uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
     needs: [build-and-push-arch-specifics]

--- a/1.28.2/rockcraft.yaml
+++ b/1.28.2/rockcraft.yaml
@@ -58,7 +58,7 @@ parts:
       if [ "${arch}" == "x86_64" ]; then
           clang_llvm="clang+llvm-18.1.8-x86_64-linux-gnu-ubuntu-18.04"
       elif [ "${arch}" == "aarch64" ]; then
-          clang_llvm="clang+llvm-18.1.8-aarch64-linux-gnu.tar.xz"
+          clang_llvm="clang+llvm-18.1.8-aarch64-linux-gnu"
       else
         echo "Invalid platform for building envoy ('${arch}'). Exiting."
         exit 1


### PR DESCRIPTION
Currently, for each change in the rockcraft repo, we publish the current state of rockcraft files and run tests on them even if files haven’t changed. We need to build only changed files but run tests on all rock images.

The PR updates pushed images after the build to only those modified rocks.

KU-1195