### PR TITLE
feat: allowing writable locations at `/tmp` and `/run`

### DIFF
--- a/1.28.2/rockcraft.yaml
+++ b/1.28.2/rockcraft.yaml
@@ -96,3 +96,11 @@ parts:
       mkdir -p ${CRAFT_PART_INSTALL}/bin/ ${CRAFT_PART_INSTALL}/etc/envoy/
       cp "linux/${CRAFT_ARCH_BUILD_FOR}/build_envoy_sizeopt_stripped/envoy" ${CRAFT_PART_INSTALL}/bin/envoy
       cp configs/envoyproxy_io_proxy.yaml ${CRAFT_PART_INSTALL}/etc/envoy/envoy.yaml
+
+  non-root-user:
+    plugin: nil
+    after:
+      - envoy
+    override-prime: |
+      craftctl default
+      install -d -o 584792 -g 584792 -m 770 run tmp


### PR DESCRIPTION
In order to be able to use this image while running as non-root in charms and workloads, we need to be able to write some files.
In general `/tmp` and `/run` are writable in hardened images: this PR changes the permissions for those folder in the final image.

This modification is similar to the one requested for the base python rock image, see https://github.com/canonical/python-rock/pull/37 for more context.